### PR TITLE
fix typo for 'experience' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ You can even affect all commands by using `universal_perms.use` and `universal_p
 2. Commands that are aliases to other commands behave weirdly when their target is forbidden/hidden, but they are visible. Here is a list of vanilla aliases to watch out for:
     * `tell` and `w` redirect to `msg`
     * `tp` redirects to `teleport`
-    * `xp` redirects to `experiance`
+    * `xp` redirects to `experience`
     * `tm` redirects to `teammsg`
 3. Compatibility with other mods isn't guaranteed if the other mods add their commands later than usual or mess with their requirements after universal perms does.


### PR DESCRIPTION
the command for /experience in the readme was misspelled slightly

you'll also want to make sure you update it on modrinth