### PR TITLE
Fix 1.19.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ dependencies {
     modImplementation "net.fabricmc.fabric-api:fabric-api:$fabric_version"
     modImplementation "me.lucko:fabric-permissions-api:0.2-SNAPSHOT"
 
-    implementation("com.github.LlamaLad7:MixinExtras:0.0.12")
-    include("com.github.LlamaLad7:MixinExtras:0.0.12")
-    annotationProcessor("com.github.LlamaLad7:MixinExtras:0.0.12")
+    implementation("com.github.LlamaLad7:MixinExtras:0.1.1")
+    include("com.github.LlamaLad7:MixinExtras:0.1.1")
+    annotationProcessor("com.github.LlamaLad7:MixinExtras:0.1.1")
 }
 
 processResources {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
   "depends": {
     "fabricloader": ">=0.14.9",
     "fabric": "*",
-    "minecraft": "1.19.2",
+    "minecraft": "~1.19.2",
     "fabric-permissions-api-v0": "*"
   }
 }


### PR DESCRIPTION
Fix 1.19.3 by making the compatible version(s) declared in `fabric.mod.json` less strict.

Also update MixinExtras because 0.0.12 was removed from JitPack, I guess.