### PR TITLE
1.20.3-rc.1 version bump prior to 1.20.3 release...  (gitignore + gradle 8.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ run/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+# Ignore vscode
+.vscode/

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.2
-loader_version=0.14.22
+minecraft_version=1.20.3-rc1
+yarn_mappings=1.20.3-rc1+build.2
+loader_version=0.14.24
 # Mod Properties
-mod_version=1.0.4
+mod_version=1.0.5
 maven_group=io.github.mattidragon
 archives_base_name=universal_perms
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.89.3+1.20.2
+fabric_version=0.90.9+1.20.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
     "universal_perms.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.9",
+    "fabricloader": ">=0.14.24",
     "fabric": "*",
     "minecraft": ">=1.20.2",
     "fabric-permissions-api-v0": "*"


### PR DESCRIPTION
this might just work as is once LP for 1.20.3 releases with the >=1.20.2 .
I also avoided any code changes like last time, and added .gitignore for vscode dir, gradle 8.5 bump.
All mappings appear to be the same as 1.20.2 .
