### PR TITLE
Updated mixins to version 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,14 @@
 plugins {
-    id 'fabric-loom' version '1.11-SNAPSHOT'
+    id 'fabric-loom' version "$loom_version"
     id 'maven-publish'
 }
 
 version = project.mod_version
 group = project.maven_group
+
+base {
+    archivesName = project.archives_base_name
+}
 
 repositories {
     maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
@@ -16,8 +20,8 @@ dependencies {
     mappings "net.fabricmc:yarn:$yarn_mappings:v2"
     modImplementation "net.fabricmc:fabric-loader:$loader_version"
 
-    modImplementation "net.fabricmc.fabric-api:fabric-api:$fabric_version"
-    modImplementation "me.lucko:fabric-permissions-api:0.4.1"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:$fabric_api_version"
+    modImplementation "me.lucko:fabric-permissions-api:$fabric_permissions_api_version"
 }
 
 processResources {
@@ -37,9 +41,10 @@ java {
     withSourcesJar()
 }
 
+def archivesName = project.base.archivesName.get()
 jar {
     from("LICENSE") {
-        rename { "${it}_${project.archivesBaseName}" }
+        rename { "${it}_${archivesName}" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.7
-yarn_mappings=1.21.7+build.6
-loader_version=0.16.14
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.3
+loader_version=0.18.4
+loom_version=1.14-SNAPSHOT
 # Mod Properties
-mod_version=1.0.8
+mod_version=1.0.9
 maven_group=io.github.mattidragon
 archives_base_name=universal_perms
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.128.2+1.21.7
+fabric_api_version=0.140.2+1.21.11
+fabric_permissions_api_version=0.6.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/io/github/mattidragon/universalperms/mixin/AdminItemWarningMixin.java
+++ b/src/main/java/io/github/mattidragon/universalperms/mixin/AdminItemWarningMixin.java
@@ -1,23 +1,33 @@
 package io.github.mattidragon.universalperms.mixin;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import io.github.mattidragon.universalperms.ModPermissions;
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SpawnEggItem;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin({BlockItem.class, SpawnEggItem.class})
 public class AdminItemWarningMixin {
-    @ModifyExpressionValue(method = "shouldShowOperatorBlockWarnings", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerEntity;getPermissionLevel()I"))
-    private int modifyLevelForWarning(int original, ItemStack stack, PlayerEntity player) {
-        if (player.getWorld().isClient) return original;
-
-        return Permissions.getPermissionValue(player, ModPermissions.USE_ADMIN_TOOLS)
-                .map(hasPermission -> hasPermission ? 1000 : -1000)
-                .orElse(original);
+    @Inject(
+        method = "shouldShowOperatorBlockWarnings",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void universal_perms$overrideWarnings(
+        ItemStack stack,
+        @Nullable PlayerEntity player,
+        CallbackInfoReturnable<Boolean> cir
+    ) {
+        if (player == null || player.getEntityWorld().isClient()) return;
+        if (Permissions.getPermissionValue(player, ModPermissions.USE_ADMIN_TOOLS) == TriState.FALSE) {
+            cir.setReturnValue(false);
+        }
     }
 }

--- a/src/main/java/io/github/mattidragon/universalperms/mixin/EntitySelectorMixin.java
+++ b/src/main/java/io/github/mattidragon/universalperms/mixin/EntitySelectorMixin.java
@@ -10,7 +10,13 @@ import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(EntitySelector.class)
 public class EntitySelectorMixin {
-    @ModifyExpressionValue(method = "checkSourcePermission", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/command/ServerCommandSource;hasElevatedPermissions()Z"))
+    @ModifyExpressionValue(
+        method = "checkSourcePermission",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/command/permission/PermissionPredicate;hasPermission(Lnet/minecraft/command/permission/Permission;)Z"
+        )
+    )
     private boolean applySelectorPermission(boolean old, ServerCommandSource source) {
         return Permissions.getPermissionValue(source, ModPermissions.USE_SELECTOR).orElse(old);
     }

--- a/src/main/java/io/github/mattidragon/universalperms/mixin/PlayerManagerMixin.java
+++ b/src/main/java/io/github/mattidragon/universalperms/mixin/PlayerManagerMixin.java
@@ -3,6 +3,8 @@ package io.github.mattidragon.universalperms.mixin;
 import io.github.mattidragon.universalperms.ModPermissions;
 import io.github.mattidragon.universalperms.UniversalPerms;
 import me.lucko.fabric.api.permissions.v0.Options;
+import net.minecraft.command.permission.LeveledPermissionPredicate;
+import net.minecraft.command.permission.PermissionLevel;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,16 +13,27 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(PlayerManager.class)
 public abstract class PlayerManagerMixin {
-    @ModifyArg(method = "sendCommandTree(Lnet/minecraft/server/network/ServerPlayerEntity;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/server/PlayerManager;sendCommandTree(Lnet/minecraft/server/network/ServerPlayerEntity;I)V"))
-    private int overridePermissionLevelForClient(ServerPlayerEntity player, int old) {
+    @ModifyArg(
+        method = "sendCommandTree(Lnet/minecraft/server/network/ServerPlayerEntity;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/PlayerManager;sendCommandTree(Lnet/minecraft/server/network/ServerPlayerEntity;Lnet/minecraft/command/permission/LeveledPermissionPredicate;)V"
+        )
+    )
+    private LeveledPermissionPredicate overridePermissionLevelForClient(
+        ServerPlayerEntity player,
+        LeveledPermissionPredicate original
+    ) {
         return Options.get(player, ModPermissions.PERMISSION_LEVEL).map(val -> {
             try {
-                return Integer.parseInt(val);
+                var numericPermission = Integer.parseInt(val);
+                return LeveledPermissionPredicate.fromLevel(
+                    PermissionLevel.fromLevel(numericPermission)
+                );
             } catch (NumberFormatException e) {
                 UniversalPerms.LOGGER.warn("Invalid permission level override for {}", this);
                 return null;
             }
-        }).orElse(old);
+        }).orElse(original);
     }
 }

--- a/src/main/java/io/github/mattidragon/universalperms/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/io/github/mattidragon/universalperms/mixin/ServerPlayNetworkHandlerMixin.java
@@ -13,22 +13,46 @@ import org.spongepowered.asm.mixin.injection.At;
 public class ServerPlayNetworkHandlerMixin {
     @Shadow public ServerPlayerEntity player;
 
-    @ModifyExpressionValue(method = "onQueryEntityNbt", at = @At(value = "INVOKE", target = "net/minecraft/server/network/ServerPlayerEntity.hasPermissionLevel(I)Z"))
+    @ModifyExpressionValue(
+        method = "onQueryEntityNbt",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/command/permission/PermissionPredicate;hasPermission(Lnet/minecraft/command/permission/Permission;)Z"
+        )
+    )
     private boolean checkEntityNbtQueryPerms(boolean old) {
         return Permissions.getPermissionValue(this.player, ModPermissions.QUERY_ENTITY_NBT).orElse(old);
     }
 
-    @ModifyExpressionValue(method = "onQueryBlockNbt", at = @At(value = "INVOKE", target = "net/minecraft/server/network/ServerPlayerEntity.hasPermissionLevel(I)Z"))
+    @ModifyExpressionValue(
+        method = "onQueryBlockNbt",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/command/permission/PermissionPredicate;hasPermission(Lnet/minecraft/command/permission/Permission;)Z"
+        )
+    )
     private boolean checkBlockNbtQueryPerms(boolean old) {
         return Permissions.getPermissionValue(this.player, ModPermissions.QUERY_BLOCK_NBT).orElse(old);
     }
 
-    @ModifyExpressionValue(method = "onUpdateDifficulty", at = @At(value = "INVOKE", target = "net/minecraft/server/network/ServerPlayerEntity.hasPermissionLevel(I)Z"))
+    @ModifyExpressionValue(
+        method = "onUpdateDifficulty",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/command/permission/PermissionPredicate;hasPermission(Lnet/minecraft/command/permission/Permission;)Z"
+        )
+    )
     private boolean checkDifficultyUpdatePerms(boolean old) {
         return Permissions.getPermissionValue(this.player, ModPermissions.UPDATE_DIFFICULTY).orElse(old);
     }
 
-    @ModifyExpressionValue(method = "onUpdateDifficultyLock", at = @At(value = "INVOKE", target = "net/minecraft/server/network/ServerPlayerEntity.hasPermissionLevel(I)Z"))
+    @ModifyExpressionValue(
+        method = "onUpdateDifficultyLock",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/command/permission/PermissionPredicate;hasPermission(Lnet/minecraft/command/permission/Permission;)Z"
+        )
+    )
     private boolean checkDifficultyLockUpdatePerms(boolean old) {
         return Permissions.getPermissionValue(this.player, ModPermissions.UPDATE_DIFFICULTY_LOCK).orElse(Permissions.getPermissionValue(this.player, ModPermissions.UPDATE_DIFFICULTY).orElse(old));
     }

--- a/src/main/java/io/github/mattidragon/universalperms/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/io/github/mattidragon/universalperms/mixin/ServerPlayerEntityMixin.java
@@ -5,6 +5,9 @@ import com.mojang.authlib.GameProfile;
 import io.github.mattidragon.universalperms.ModPermissions;
 import io.github.mattidragon.universalperms.UniversalPerms;
 import me.lucko.fabric.api.permissions.v0.Options;
+import net.minecraft.command.permission.LeveledPermissionPredicate;
+import net.minecraft.command.permission.PermissionLevel;
+import net.minecraft.command.permission.PermissionPredicate;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.World;
@@ -21,20 +24,23 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity {
         super(world, profile);
     }
 
-    @ModifyReturnValue(method = "getPermissionLevel", at = @At("RETURN"))
-    private int overridePermissionLevel(int old) {
-        if (universal_perms$isCheckingPermission)
-            return old;
+    @ModifyReturnValue(method = "getPermissions", at = @At("RETURN"))
+    private PermissionPredicate overridePermissionLevel(PermissionPredicate original) {
+        if (universal_perms$isCheckingPermission) return original;
         universal_perms$isCheckingPermission = true;
+
         var result = Options.get(this, ModPermissions.PERMISSION_LEVEL).map(val -> {
             try {
-                return Integer.parseInt(val);
+                var numericPermission = Integer.parseInt(val);
+                return (PermissionPredicate) LeveledPermissionPredicate.fromLevel(
+                    PermissionLevel.fromLevel(numericPermission)
+                );
             } catch (NumberFormatException e) {
                 UniversalPerms.LOGGER.warn("Invalid permission level override for " + this);
                 return null;
             }
-        }).orElse(old);
-        universal_perms$isCheckingPermission = true;
+        }).orElse(original);
+        universal_perms$isCheckingPermission = false;
         return result;
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,9 +20,9 @@
     "universal_perms.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.16.14",
+    "fabricloader": ">=0.18.4",
     "fabric": "*",
-    "minecraft": ">=1.21.7",
+    "minecraft": ">=1.21.11",
     "fabric-permissions-api-v0": "*"
   }
 }

--- a/src/main/resources/universal_perms.mixins.json
+++ b/src/main/resources/universal_perms.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "io.github.mattidragon.universalperms.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "AdminItemWarningMixin",
     "CommandManagerMixin",


### PR DESCRIPTION
Some permission-related functions were changed to use static LeveledPermissionPredicate instances instead. I updated the mixixins so it compiles again.

Except for the `ModPermissions.PERMISSION_LEVEL` feature, I've tested the mod in my own server and as far as I can see, everything works.

I didn't change the bussiness logic of the mod except for the ServerPlayerEntityMixin class. See comment in that file for more information.